### PR TITLE
Fix Alembic environment module path resolution

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,7 +1,12 @@
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+import sys
+from pathlib import Path
+
 from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.db.session import DATABASE_URL
 from app.models import Base


### PR DESCRIPTION
## Summary
- ensure the Alembic environment script adds the project root to `sys.path`
- allow Alembic to import the app database configuration without module errors

## Testing
- `alembic upgrade head`
