### PR TITLE
Add admin QR endpoint for consent listings

### DIFF
--- a/app/api/routers/admin/qr.py
+++ b/app/api/routers/admin/qr.py
@@ -1,4 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_admin
@@ -16,3 +19,19 @@ def generate_listing_qr(listing_id: int, db: Session = Depends(get_db)) -> dict[
         raise HTTPException(status_code=404, detail="Listing not found")
     token = create_qr_token(listing.id)
     return {"token": token}
+
+
+@router.get("/admin/listings/{listing_id}/qr", tags=["Admin"])
+def get_listing_qr_image(
+    listing_id: int, request: Request, db: Session = Depends(get_db)
+) -> RedirectResponse:
+    listing = db.query(Listing).filter(Listing.id == listing_id).first()
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    consent_url = request.url_for("get_consent_template", listing_id=listing.id)
+    qr_url = (
+        "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data="
+        f"{quote(str(consent_url), safe='')}"
+    )
+    return RedirectResponse(url=qr_url)

--- a/tests/test_admin_qr.py
+++ b/tests/test_admin_qr.py
@@ -1,0 +1,43 @@
+from urllib.parse import urlparse, parse_qs
+
+from sqlalchemy.orm import Session
+
+from app.models import AdminRoleEnum, AdminUser
+from app.schemas.listing import ListingOut
+from app.utils.security import get_password_hash
+from tests.conftest import SimpleTestClient
+from tests.test_admin_auth import login
+
+
+def test_admin_can_generate_listing_qr_link(
+    client: SimpleTestClient, db_session: Session
+) -> None:
+    admin = AdminUser(
+        email="qr-admin@example.com",
+        hashed_password=get_password_hash("Secretpass1!"),
+        role=AdminRoleEnum.SUPERADMIN.value,
+    )
+    db_session.add(admin)
+    db_session.commit()
+    db_session.refresh(admin)
+
+    tokens = login(client, admin.email, "Secretpass1!")
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    listing_resp = client.post(
+        "/admin/listings",
+        json={"name": "Test Listing", "slug": "test-listing"},
+        headers=headers,
+    )
+    assert listing_resp.status_code == 200
+    listing = ListingOut(**listing_resp.json())
+
+    qr_resp = client.get(f"/admin/listings/{listing.id}/qr", headers=headers)
+    assert qr_resp.status_code in (302, 303, 307)
+    location = qr_resp.headers.get("location")
+    assert location and location.startswith("https://api.qrserver.com/v1/create-qr-code/")
+
+    parsed = urlparse(location)
+    params = parse_qs(parsed.query)
+    assert "data" in params
+    assert params["data"][0].endswith(f"/public/listings/{listing.id}/consent")


### PR DESCRIPTION
## Summary
- add an admin QR endpoint that redirects to a generated consent URL code for a listing
- ensure the generated QR code points to the public consent page for the listing
- add coverage to validate the new endpoint and QR target URL

## Testing
- pytest