### PR TITLE
Update public redirect, enable CORS, and route QR to public site

### DIFF
--- a/app/api/routers/public/qr.py
+++ b/app/api/routers/public/qr.py
@@ -2,11 +2,13 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.db.session import get_db
 from app.models import Listing
 from app.services.qr import decode_qr_token
 
 router = APIRouter()
+settings = get_settings()
 
 
 @router.get("/q/{token}", tags=["Public"])
@@ -21,4 +23,7 @@ def resolve_qr(token: str, db: Session = Depends(get_db)) -> Response:
     listing = db.query(Listing).filter(Listing.id == listing_id).first()
     if not listing:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Listing not found")
-    return RedirectResponse(url=f"/public/listings/{listing.id}", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+    base_url = (settings.public_frontend_base_url or "").rstrip("/")
+    listing_path = f"/public/listings/{listing.id}"
+    redirect_url = f"{base_url}{listing_path}" if base_url else listing_path
+    return RedirectResponse(url=redirect_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,6 +14,14 @@ class Settings(BaseSettings):
     database_url: Optional[str] = Field(None, env="DATABASE_URL")
     sqlite_url: str = Field("sqlite:///./app.db", env="SQLITE_URL")
 
+    public_frontend_base_url: Optional[str] = Field(
+        "https://web.mrhost.top", env="PUBLIC_FRONTEND_BASE_URL"
+    )
+    cors_allow_origins: list[str] = Field(
+        default_factory=lambda: ["https://web.mrhost.top"],
+        env="CORS_ALLOW_ORIGINS",
+    )
+
     jwt_algorithm: str = Field("HS256", env="JWT_ALGORITHM")
     qr_token_expire_minutes: int = Field(60 * 24, env="QR_TOKEN_EXPIRE_MINUTES")
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes import router
 from app.core.config import get_settings
@@ -6,6 +7,13 @@ from app.core.config import get_settings
 settings = get_settings()
 
 app = FastAPI(title=settings.app_name, debug=settings.debug)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_allow_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(router)
 
 

--- a/tests/test_admin_qr.py
+++ b/tests/test_admin_qr.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse, parse_qs
 
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.models import AdminRoleEnum, AdminUser
 from app.schemas.listing import ListingOut
 from app.utils.security import get_password_hash
@@ -40,4 +41,6 @@ def test_admin_can_generate_listing_qr_link(
     parsed = urlparse(location)
     params = parse_qs(parsed.query)
     assert "data" in params
-    assert params["data"][0].endswith(f"/public/listings/{listing.id}/consent")
+    settings = get_settings()
+    expected_base = (settings.public_frontend_base_url or "").rstrip("/")
+    assert params["data"][0] == f"{expected_base}/public/listings/{listing.id}"


### PR DESCRIPTION
## Summary
- redirect guests scanning QR codes to the public web host using the configured frontend base URL
- add configurable frontend base URL and allowed CORS origins to the application settings
- enable CORS middleware so the public site can call the API without browser rejections
- generate admin QR codes that encode the public listing URL instead of the API consent endpoint

## Testing
- pytest