### PR TITLE
Update Docker Compose migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Use `.env.example` for local development (SQLite). For production deployments wi
 docker compose -f docker-compose.dev.yml up --build
 ```
 
+Run database migrations in the running container:
+
+```bash
+docker compose -f docker-compose.dev.yml exec api alembic upgrade head
+```
+
 ### Production (Postgres)
 
 ```bash


### PR DESCRIPTION
## Summary
- update README development Docker Compose instructions to run Alembic migrations against the api service
- align container naming in the migration command with the service defined in docker-compose.dev.yml

## Testing
- not run (not requested)