### PR TITLE
Allow all origins in CORS configuration

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,10 +17,8 @@ class Settings(BaseSettings):
     public_frontend_base_url: Optional[str] = Field(
         "https://web.mrhost.top", env="PUBLIC_FRONTEND_BASE_URL"
     )
-    cors_allow_origins: list[str] = Field(
-        default_factory=lambda: ["https://web.mrhost.top"],
-        env="CORS_ALLOW_ORIGINS",
-    )
+    cors_allow_origins: list[str] = Field(default_factory=list, env="CORS_ALLOW_ORIGINS")
+    cors_allow_origin_regex: str = Field(".*", env="CORS_ALLOW_ORIGIN_REGEX")
 
     jwt_algorithm: str = Field("HS256", env="JWT_ALGORITHM")
     qr_token_expire_minutes: int = Field(60 * 24, env="QR_TOKEN_EXPIRE_MINUTES")

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ app = FastAPI(title=settings.app_name, debug=settings.debug)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_allow_origins,
+    allow_origin_regex=settings.cors_allow_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow configuring a CORS origin regex with a permissive default for development
- apply the CORS origin regex to the FastAPI middleware to accept requests from any origin

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d0ef2068832fb0ae393d95221c82)