### PR TITLE
Add endpoint to generate QR codes from URLs

### DIFF
--- a/app/api/routers/public/qr.py
+++ b/app/api/routers/public/qr.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
@@ -29,3 +31,18 @@ def resolve_qr(token: str, db: Session = Depends(get_db)) -> Response:
         listing_path = f"{listing_path}?require_consent=true"
     redirect_url = f"{base_url}{listing_path}" if base_url else listing_path
     return RedirectResponse(url=redirect_url, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+@router.get("/qr", tags=["Public"])
+def generate_qr_from_url(url: str | None = None) -> RedirectResponse:
+    if not url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A URL parameter is required to generate a QR code",
+        )
+
+    qr_url = (
+        "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data="
+        f"{quote(url, safe='')}"
+    )
+    return RedirectResponse(url=qr_url)

--- a/tests/test_public_qr_link.py
+++ b/tests/test_public_qr_link.py
@@ -1,0 +1,22 @@
+from urllib.parse import parse_qs, urlparse
+
+from tests.conftest import SimpleTestClient
+
+
+def test_generate_qr_from_url(client: SimpleTestClient) -> None:
+    response = client.get("/qr", params={"url": "https://example.com/path?query=1"})
+
+    assert response.status_code in (302, 303, 307)
+    location = response.headers.get("location")
+    assert location and location.startswith("https://api.qrserver.com/v1/create-qr-code/")
+
+    parsed = urlparse(location)
+    params = parse_qs(parsed.query)
+    assert params.get("data") == ["https://example.com/path?query=1"]
+
+
+def test_generate_qr_from_url_requires_param(client: SimpleTestClient) -> None:
+    response = client.get("/qr")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "A URL parameter is required to generate a QR code"


### PR DESCRIPTION
## Summary
- add a public endpoint that converts a supplied URL into a QR code image via redirect
- validate that the URL parameter is provided before generating the QR code
- add tests covering successful QR generation and missing URL errors

## Testing
- pytest tests/test_public_qr_link.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926288b27c8832fa63a5346e8101aa3)