### PR TITLE
Add admin endpoints for listing specific items

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,6 +1,7 @@
 from logging.config import fileConfig
 
 import sys
+import os
 from pathlib import Path
 
 from alembic import context
@@ -8,7 +9,6 @@ from sqlalchemy import engine_from_config, pool
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from app.db.session import DATABASE_URL
 from app.models import Base
 
 config = context.config
@@ -16,7 +16,8 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-config.set_main_option("sqlalchemy.url", DATABASE_URL)
+database_url = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+config.set_main_option("sqlalchemy.url", database_url)
 
 
 def run_migrations_offline() -> None:

--- a/alembic/versions/20240716_000001_specific_items_table.py
+++ b/alembic/versions/20240716_000001_specific_items_table.py
@@ -1,0 +1,38 @@
+"""Create specific_items table
+
+Revision ID: 20240716_000001
+Revises: 20240715_000003
+Create Date: 2024-07-16 00:00:01.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20240716_000001"
+down_revision = "20240715_000003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "specific_items",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("listing_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["listing_id"], ["listings.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("listing_id", "slug", name="uq_specific_item_slug"),
+    )
+    op.create_index(op.f("ix_specific_items_id"), "specific_items", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_specific_items_id"), table_name="specific_items")
+    op.drop_table("specific_items")

--- a/app/api/routers/admin/specific_item.py
+++ b/app/api/routers/admin/specific_item.py
@@ -1,0 +1,107 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_current_admin
+from app.db.session import get_db
+from app.models import Listing, SpecificItem
+from app.schemas.specific_item import SpecificItemOut, SpecificItemUpdate
+
+router = APIRouter(dependencies=[Depends(get_current_admin)])
+
+
+def _get_listing_or_404(listing_id: int, db: Session) -> Listing:
+    listing = db.query(Listing).filter(Listing.id == listing_id).first()
+    if not listing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Listing not found")
+    return listing
+
+
+def _get_specific_item_or_404(
+    listing_id: int, slug: str, db: Session
+) -> SpecificItem:
+    item = (
+        db.query(SpecificItem)
+        .filter(
+            SpecificItem.listing_id == listing_id,
+            SpecificItem.slug == slug,
+        )
+        .first()
+    )
+    if not item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Specific item not found"
+        )
+    return item
+
+
+@router.get("/admin/listings/{listing_id}/items", response_model=list[SpecificItemOut], tags=["Admin"])
+def list_specific_items(listing_id: int, db: Session = Depends(get_db)) -> list[SpecificItemOut]:
+    _get_listing_or_404(listing_id, db)
+    return db.query(SpecificItem).filter(SpecificItem.listing_id == listing_id).all()
+
+
+@router.get(
+    "/admin/listings/{listing_id}/{specific_item}",
+    response_model=SpecificItemOut,
+    tags=["Admin"],
+)
+def get_specific_item(
+    listing_id: int, specific_item: str, db: Session = Depends(get_db)
+) -> SpecificItemOut:
+    _get_listing_or_404(listing_id, db)
+    return _get_specific_item_or_404(listing_id, specific_item, db)
+
+
+@router.put(
+    "/admin/listings/{listing_id}/{specific_item}",
+    response_model=SpecificItemOut,
+    tags=["Admin"],
+)
+def update_specific_item(
+    listing_id: int,
+    specific_item: str,
+    payload: SpecificItemUpdate,
+    db: Session = Depends(get_db),
+) -> SpecificItemOut:
+    _get_listing_or_404(listing_id, db)
+    item = _get_specific_item_or_404(listing_id, specific_item, db)
+
+    data = payload.dict(exclude_unset=True)
+    if "slug" in data:
+        existing = (
+            db.query(SpecificItem)
+            .filter(
+                SpecificItem.listing_id == listing_id,
+                SpecificItem.slug == data["slug"],
+                SpecificItem.id != item.id,
+            )
+            .first()
+        )
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A specific item with this slug already exists",
+            )
+
+    for field, value in data.items():
+        setattr(item, field, value)
+
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete(
+    "/admin/listings/{listing_id}/{specific_item}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["Admin"],
+)
+def delete_specific_item(
+    listing_id: int, specific_item: str, db: Session = Depends(get_db)
+):
+    _get_listing_or_404(listing_id, db)
+    item = _get_specific_item_or_404(listing_id, specific_item, db)
+    db.delete(item)
+    db.commit()
+    return None

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -6,6 +6,7 @@ from app.api.routers.admin import faq as admin_faq
 from app.api.routers.admin import listings as admin_listings
 from app.api.routers.admin import logs as admin_logs
 from app.api.routers.admin import page_description as admin_page_description
+from app.api.routers.admin import specific_item as admin_specific_item
 from app.api.routers.admin import qr as admin_qr
 from app.api.routers.admin import tutorial as admin_tutorial
 from app.api.routers.admin import users as admin_users
@@ -25,6 +26,7 @@ router.include_router(admin_qr.router)
 router.include_router(admin_consent.router)
 router.include_router(admin_faq.router)
 router.include_router(admin_page_description.router)
+router.include_router(admin_specific_item.router)
 router.include_router(admin_tutorial.router)
 router.include_router(admin_logs.router)
 router.include_router(admin_users.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -16,6 +16,7 @@ from app.models.entities import (
     Listing,
     PageDescription,
     PageDescriptionTranslation,
+    SpecificItem,
     Tutorial,
     TutorialTranslation,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "Listing",
     "PageDescription",
     "PageDescriptionTranslation",
+    "SpecificItem",
     "Tutorial",
     "TutorialTranslation",
 ]

--- a/app/models/entities.py
+++ b/app/models/entities.py
@@ -46,6 +46,26 @@ class Listing(Base, TimestampMixin):
         back_populates="listing",
         cascade="all, delete-orphan",
     )
+    specific_items = relationship(
+        "SpecificItem", back_populates="listing", cascade="all, delete-orphan"
+    )
+
+
+class SpecificItem(Base, TimestampMixin):
+    __tablename__ = "specific_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    listing_id = Column(
+        Integer, ForeignKey("listings.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String(255), nullable=False)
+    slug = Column(String(255), nullable=False)
+
+    listing = relationship("Listing", back_populates="specific_items")
+
+    __table_args__ = (
+        UniqueConstraint("listing_id", "slug", name="uq_specific_item_slug"),
+    )
 
 
 class ConsentTemplateStatusEnum(str, Enum):

--- a/app/schemas/specific_item.py
+++ b/app/schemas/specific_item.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class SpecificItemBase(BaseModel):
+    name: str
+    slug: str
+
+
+class SpecificItemUpdate(BaseModel):
+    name: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class SpecificItemOut(SpecificItemBase):
+    id: int
+    listing_id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add a SpecificItem model, schema, and migration for listing-level specific items
- expose admin endpoints to list, retrieve, update, and delete specific items per listing
- register the new router and adjust Alembic to respect DATABASE_URL from the environment

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927421b8844832fb2d8c56bf5b7140c)