### PR TITLE
Normalize timezone handling and CORS defaults

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,10 +7,15 @@ from app.core.config import get_settings
 settings = get_settings()
 
 app = FastAPI(title=settings.app_name, debug=settings.debug)
+cors_origins = settings.cors_allow_origins or (
+    [settings.public_frontend_base_url]
+    if settings.public_frontend_base_url
+    else ["*"]
+)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.cors_allow_origins,
-    allow_origin_regex=settings.cors_allow_origin_regex,
+    allow_origins=cors_origins,
+    allow_origin_regex=settings.cors_allow_origin_regex or None,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/models/entities.py
+++ b/app/models/entities.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from uuid import uuid4
 
@@ -23,9 +23,14 @@ def json_type():
 
 
 class TimestampMixin:
-    created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
     updated_at = Column(
-        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
     )
 
 
@@ -242,7 +247,11 @@ class AdminUser(Base, TimestampMixin):
     role = Column(String(50), default=AdminRoleEnum.ADMIN.value, nullable=False)
     totp_secret = Column(String(64), nullable=True)
     totp_enabled = Column(Boolean, default=False, nullable=False)
-    password_changed_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    password_changed_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
     last_login_at = Column(DateTime(timezone=True), nullable=True)
 
     invites_created = relationship("AdminInvite", back_populates="created_by", foreign_keys="AdminInvite.created_by_id")

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -1,7 +1,7 @@
 import base64
 import secrets
 import string
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from hashlib import pbkdf2_hmac, sha256
 from typing import Any, Dict
 
@@ -15,7 +15,7 @@ settings = get_settings()
 
 def create_access_token(data: Dict[str, Any], expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (
+    expire = datetime.now(timezone.utc) + (
         expires_delta or timedelta(minutes=settings.access_token_expire_minutes)
     )
     to_encode.update({"exp": expire})


### PR DESCRIPTION
## Summary
- normalize datetime defaults and comparisons to ensure timezone-aware UTC values
- issue JWT expirations with aware UTC timestamps to prevent naive/aware mismatches
- configure CORS middleware with sensible default origins to avoid frontend registration errors

## Testing
- pytest tests/test_admin_auth.py -k register

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69299e62de5c832f93c8a43fbf0a5905)